### PR TITLE
Adjusting resources for dellyGermline workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2   - 2024-04-22
+ - Adjust resources based on testing needs
 ## 2.0.1   - 2024-03-13
  - Add outputFileNamePrefix for project level naming of outfiles
 ## 2.0.0   - 2024-01-31

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ Parameter|Value|Default|Description
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`mergeSVSites.jobMemory`|Int|12|Memory allocated for this job
-`mergeSVSites.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`svGenotype.jobMemory`|Int|12|Memory allocated for this job
-`svGenotype.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`mergeSVSamples.jobMemory`|Int|12|Memory allocated for this job
-`mergeSVSamples.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`svFilter.jobMemory`|Int|12|Memory allocated for this job
-`svFilter.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`callCNV.jobMemory`|Int|12|Memory allocated for this job
-`callCNV.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`mergeCNVSites.jobMemory`|Int|12|Memory allocated for this job
-`mergeCNVSites.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`cnvGenotype.jobMemory`|Int|12|Memory allocated for this job
-`cnvGenotype.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`mergeCNVSamples.jobMemory`|Int|12|Memory allocated for this job
-`mergeCNVSamples.timeout`|Int|12|Timeout in hours, needed to override imposed limits
-`cnvFilter.jobMemory`|Int|12|Memory allocated for this job
-`cnvFilter.timeout`|Int|12|Timeout in hours, needed to override imposed limits
+`mergeSVSites.jobMemory`|Int|8|Memory allocated for this job
+`mergeSVSites.timeout`|Int|4|Timeout in hours, needed to override imposed limits
+`svGenotype.jobMemory`|Int|30|Memory allocated for this job
+`svGenotype.timeout`|Int|24|Timeout in hours, needed to override imposed limits
+`mergeSVSamples.jobMemory`|Int|8|Memory allocated for this job
+`mergeSVSamples.timeout`|Int|4|Timeout in hours, needed to override imposed limits
+`svFilter.jobMemory`|Int|8|Memory allocated for this job
+`svFilter.timeout`|Int|4|Timeout in hours, needed to override imposed limits
+`callCNV.jobMemory`|Int|30|Memory allocated for this job
+`callCNV.timeout`|Int|24|Timeout in hours, needed to override imposed limits
+`mergeCNVSites.jobMemory`|Int|8|Memory allocated for this job
+`mergeCNVSites.timeout`|Int|4|Timeout in hours, needed to override imposed limits
+`cnvGenotype.jobMemory`|Int|30|Memory allocated for this job
+`cnvGenotype.timeout`|Int|24|Timeout in hours, needed to override imposed limits
+`mergeCNVSamples.jobMemory`|Int|8|Memory allocated for this job
+`mergeCNVSamples.timeout`|Int|4|Timeout in hours, needed to override imposed limits
+`cnvFilter.jobMemory`|Int|8|Memory allocated for this job
+`cnvFilter.timeout`|Int|4|Timeout in hours, needed to override imposed limits
 
 
 ### Outputs

--- a/dellyGermline.wdl
+++ b/dellyGermline.wdl
@@ -187,8 +187,8 @@ task mergeSVSites{
     Array[File] inputVcfs
     String modules
     String outputFileNamePrefix
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 8 
+    Int timeout = 4
   }
 
   parameter_meta {
@@ -225,8 +225,8 @@ task svGenotype{
     String modules
     String referenceGenome
     String dellyExclude
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 30 
+    Int timeout = 24
   }
 
   parameter_meta {
@@ -265,8 +265,8 @@ task mergeSamples{
     Array[File] genotypedBcfIndexes
     String modules
     String outputFileNamePrefix
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 8 
+    Int timeout = 4
   }
 
   parameter_meta {
@@ -301,8 +301,8 @@ task svFilter {
     File mergedBcf
     String modules
     String outputFileNamePrefix
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 8 
+    Int timeout = 4
   }
 
   parameter_meta {
@@ -345,8 +345,8 @@ task callCNV {
     String modules
     String referenceGenome
     String genomeMap
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 30 
+    Int timeout = 24
   }
 
   parameter_meta {
@@ -383,8 +383,8 @@ task mergeCNVSites {
     Array[File] cnvBcfs
     String modules
     String outputFileNamePrefix
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 8 
+    Int timeout = 4
   }
 
   parameter_meta {
@@ -421,8 +421,8 @@ task cnvGenotype {
     String modules
     String referenceGenome
     String genomeMap
-    Int jobMemory = 12 
-    Int timeout = 12
+    Int jobMemory = 30 
+    Int timeout = 24
   }
 
   parameter_meta {
@@ -460,8 +460,8 @@ task cnvFilter {
     File mergedGenoBcf
     String modules
     String outputFileNamePrefix
-    Int jobMemory = 12 
-    Int timeout = 12  
+    Int jobMemory = 8 
+    Int timeout = 4  
   }
 
   parameter_meta {
@@ -489,6 +489,6 @@ task cnvFilter {
   }
 
   output {
-    File germlineCNVs = "~{outputFileNamePrefix}.germlineCNVs.vcf"
+    File germlineCNVs = "~{outputFileNamePrefix}.germlineCNV.vcf"
   }
 }

--- a/dellyGermline.wdl
+++ b/dellyGermline.wdl
@@ -477,9 +477,9 @@ task cnvFilter {
     #Index merged bcf
     bcftools index ~{mergedGenoBcf}
     #Merge
-    delly classify -f germline -o ~{outputFileNamePrefix}.germlineCNVs.bcf ~{mergedGenoBcf}
+    delly classify -f germline -o ~{outputFileNamePrefix}.germlineCNV.bcf ~{mergedGenoBcf}
     #Convert to vcf
-    bcftools view -O v -o ~{outputFileNamePrefix}.germlineCNVs.vcf ~{outputFileNamePrefix}.germlineCNVs.bcf
+    bcftools view -O v -o ~{outputFileNamePrefix}.germlineCNV.vcf ~{outputFileNamePrefix}.germlineCNV.bcf
   >>>
 
   runtime {


### PR DESCRIPTION
Increasing resources for scatter jobs and decreasing resources for all other jobs. Plus minor adjustment to output file names for consistency.